### PR TITLE
Verify ssl cert

### DIFF
--- a/lib/shodan/api.rb
+++ b/lib/shodan/api.rb
@@ -37,8 +37,13 @@ module Shodan
       # Craft the final request URL
       url = "#{@base_url}#{func}?key=#{@api_key}&#{args_string}"
       
+
       # Send the request
-      response = Net::HTTP.get_response(URI.parse(url))
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      response = http.get(uri.request_uri)
       
       # Convert the JSON data into a native Ruby hash
       data = JSON.parse(response.body)

--- a/lib/shodan/shodan.rb
+++ b/lib/shodan/shodan.rb
@@ -44,7 +44,7 @@ module Shodan
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       response = http.get(uri.request_uri)
       
       # Convert the JSON data into a native Ruby hash


### PR DESCRIPTION
I noticed last night that this gem had the peculiar `OpenSSL::SSL::VERIFY_NONE` verification mode when making requests to the Shodan API. This mode doesn't perform any verification.

This can [leave communication susceptible to man in the middle attacks](https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf), which [I'm sure](https://brakemanscanner.org/docs/warning_types/ssl_verification_bypass/) we'd much rather avoid. So I've explicitly changed that to `OpenSSL::SSL::VERIFY_PEER` to verify our peer.

This PR _should_ have no real effect on the typical usage of this gem, other than making it safer. 👍 